### PR TITLE
Upgrade to Gir.Core 0.7.0

### DIFF
--- a/src/WebCamControl.Gtk/CustomComboRow.cs
+++ b/src/WebCamControl.Gtk/CustomComboRow.cs
@@ -10,12 +10,26 @@ namespace WebCamControl.Gtk;
 /// Wrapper around <see cref="ComboRow"/> that allows C# types to be used as items.
 /// </summary>
 /// <typeparam name="T">Type of item</typeparam>
-public class CustomComboRow<T> : ComboRow
+public class CustomComboRow<T>
 {
+	private readonly ComboRow _comboRow;
 	private T[] _items = [];
 	private Dictionary<string, T> _labelToItem = new();
 
-	public CustomComboRow(IntPtr ptr, bool ownedRef) : base(ptr, ownedRef) { }
+	public CustomComboRow(ComboRow comboRow)
+	{
+		_comboRow = comboRow;
+		GObject.Object.NotifySignal.Connect(
+			_comboRow,
+			(_, _) => OnSelectedItemChanged?.Invoke(this, EventArgs.Empty),
+			detail: ComboRow.SelectedPropertyDefinition.UnmanagedName
+		);
+	}
+
+	/// <summary>
+	/// Raised when the selected item changes.
+	/// </summary>
+	public event EventHandler? OnSelectedItemChanged;
 
 	/// <summary>
 	/// Gets or sets a callback to get the label for the specified item.
@@ -23,7 +37,7 @@ public class CustomComboRow<T> : ComboRow
 	public Func<T, string> LabelCallback { get; set; } = item => item.ToString();
 
 	/// <summary>
-	/// Gets or sets the list of items to show 
+	/// Gets or sets the list of items to show
 	/// </summary>
 	/// <exception cref="ArgumentException">Thrown if multiple items have the same label</exception>
 	public IEnumerable<T> Items
@@ -48,7 +62,7 @@ public class CustomComboRow<T> : ComboRow
 				}
 			}
 
-			Model = StringList.New(labels);
+			_comboRow.Model = StringList.New(labels);
 			_labelToItem = labelToItem;
 		}
 	}
@@ -56,17 +70,17 @@ public class CustomComboRow<T> : ComboRow
 	/// <summary>
 	/// Gets the currently selected item.
 	/// </summary>
-	public new T? SelectedItem
+	public T? SelectedItem
 	{
 		get
 		{
-			var label = (StringObject?)base.SelectedItem;
+			var label = (StringObject?)_comboRow.SelectedItem;
 			return label?.String == null ? default : _labelToItem[label.String];
 		}
 		set
 		{
 			var index = (uint)Array.FindIndex(_items, item => Equals(item, value));
-			SetSelected(index);
+			_comboRow.SetSelected(index);
 		}
 	}
 }

--- a/src/WebCamControl.Gtk/ErrorDialog.cs
+++ b/src/WebCamControl.Gtk/ErrorDialog.cs
@@ -19,7 +19,7 @@ public class ErrorDialog : Adw.AlertDialog
 		: this(ex, new Builder("ErrorDialog.ui")) { }
 
 	private ErrorDialog(Exception ex, Builder builder)
-		: base(builder.GetPointer("error_dialog"), false)
+		: base(new Adw.Internal.AlertDialogHandle(builder.GetPointer("error_dialog"), false))
 	{
 		builder.Connect(this);
 		_summary.Label_ = _($"Error: {ex.Message}\n\nIf this is unexpected, please report a bug.");

--- a/src/WebCamControl.Gtk/FullWindow.blp
+++ b/src/WebCamControl.Gtk/FullWindow.blp
@@ -33,7 +33,7 @@ Adw.ApplicationWindow full_window {
               "settings-page",
             ]
 
-            Adw.ComboRow _cameraCombo {
+            Adw.ComboRow _cameraComboRow {
               title: _("Camera");
               model: Gtk.StringList {
                 // Dummy data for testing

--- a/src/WebCamControl.Gtk/FullWindow.cs
+++ b/src/WebCamControl.Gtk/FullWindow.cs
@@ -17,13 +17,15 @@ public class FullWindow : Adw.Window
 	private readonly ILogger<FullWindow> _logger;
 
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
-	[Connect] private readonly CustomComboRow<ICamera> _cameraCombo = default!; 
+	[Connect] private readonly ComboRow _cameraComboRow = default!;
 	[Connect] private readonly ListBox _controls = default!;
 	[Connect] private readonly ActionRow _exampleRow = default!;
 	[Connect] private readonly ListBox _presetsList = default!;
 	[Connect] private readonly ActionRow _panAndTiltRow = default!;
 	[Connect] private readonly Box _panAndTiltButtons = default!;
 #pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
+
+	private readonly CustomComboRow<ICamera> _cameraCombo;
 
 	public FullWindow(
 		Adw.Application app,
@@ -40,14 +42,15 @@ public class FullWindow : Adw.Window
 		ICameraManager cameraManager,
 		IPresets presets,
 		ILogger<FullWindow> logger
-	) : base(builder.GetPointer("full_window"), false)
+	) : base(new Adw.Internal.WindowHandle(builder.GetPointer("full_window"), false))
 	{
 		_cameraManager = cameraManager;
 		_presets = presets;
 		_logger = logger;
 		builder.Connect(this);
+		_cameraCombo = new CustomComboRow<ICamera>(_cameraComboRow);
 		// TODO: Configure proper icon
-		
+
 		InitializeWidgets();
 	}
 
@@ -70,22 +73,18 @@ public class FullWindow : Adw.Window
 		_cameraCombo.LabelCallback = camera => $"{camera.Name} ({camera.RawName})";
 		_cameraCombo.Items = _cameraManager.Cameras;
 		_cameraCombo.SelectedItem = _cameraManager.SelectedCamera;
-		NotifySignal.Connect(
-			_cameraCombo,
-			(_, _) =>
+		_cameraCombo.OnSelectedItemChanged += (_, _) =>
+		{
+			var newCamera = _cameraCombo.SelectedItem;
+			if (newCamera == null)
 			{
-				var newCamera = _cameraCombo.SelectedItem;
-				if (newCamera == null)
-				{
-					return;
-				}
-				
-				_logger.LogInformation("Changing camera to {CameraName}", newCamera.Name);
-				_cameraManager.SelectedCamera = newCamera;
-				InitializeCamera();
-			},
-			detail: ComboRow.SelectedPropertyDefinition.UnmanagedName
-		);
+				return;
+			}
+
+			_logger.LogInformation("Changing camera to {CameraName}", newCamera.Name);
+			_cameraManager.SelectedCamera = newCamera;
+			InitializeCamera();
+		};
 	}
 
 	/// <summary>

--- a/src/WebCamControl.Gtk/MiniWindow.cs
+++ b/src/WebCamControl.Gtk/MiniWindow.cs
@@ -39,7 +39,7 @@ public class MiniWindow : Adw.Window
 		Builder builder,
 		ICameraManager cameraManager,
 		IPresets presets
-	) : base(builder.GetPointer("mini_window"), false)
+	) : base(new Adw.Internal.WindowHandle(builder.GetPointer("mini_window"), false))
 	{
 		_camera = cameraManager.SelectedCamera;
 		_presets = presets;

--- a/src/WebCamControl.Gtk/SavePresetDialog.blp
+++ b/src/WebCamControl.Gtk/SavePresetDialog.blp
@@ -15,7 +15,7 @@ Adw.AlertDialog save_preset_dialog {
       Adw.EntryRow _name {
         title: _("Name");
       }
-      Adw.ComboRow _destination {
+      Adw.ComboRow _destinationRow {
         title: _("Save As");
       }
     }

--- a/src/WebCamControl.Gtk/SavePresetDialog.cs
+++ b/src/WebCamControl.Gtk/SavePresetDialog.cs
@@ -17,20 +17,23 @@ public class SavePresetDialog : Adw.AlertDialog
 	
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 	[Connect] private readonly EntryRow _name = default!;
-	[Connect] private readonly CustomComboRow<DestinationRow> _destination = default!;
+	[Connect] private readonly ComboRow _destinationRow = default!;
 #pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
-	
+
+	private readonly CustomComboRow<DestinationRow> _destination;
+
 	public SavePresetDialog(ICameraManager cameraManager, IPresets presets)
 		: this(new Builder("SavePresetDialog.ui"), cameraManager, presets)
 	{
 	}
 
 	private SavePresetDialog(Builder builder, ICameraManager cameraManager, IPresets presets)
-		: base(builder.GetPointer("save_preset_dialog"), false)
+		: base(new Adw.Internal.AlertDialogHandle(builder.GetPointer("save_preset_dialog"), false))
 	{
 		_camera = cameraManager.SelectedCamera;
 		_presets = presets;
 		builder.Connect(this);
+		_destination = new CustomComboRow<DestinationRow>(_destinationRow);
 		Validate();
 		PopulateSaveDropdown();
 		AttachEvents();

--- a/src/WebCamControl.Gtk/WebCamControl.Gtk.csproj
+++ b/src/WebCamControl.Gtk/WebCamControl.Gtk.csproj
@@ -15,8 +15,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="GirCore.Adw-1" Version="0.5.0" />
-      <PackageReference Include="GirCore.Gdk-4.0" Version="0.5.0" />
+      <PackageReference Include="GirCore.Adw-1" Version="0.7.0" />
+      <PackageReference Include="GirCore.Gdk-4.0" Version="0.7.0" />
+      <PackageReference Include="GirCore.GObject-2.0.Integration" Version="0.7.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />

--- a/src/WebCamControl.Gtk/Widgets/CameraControlSlider.cs
+++ b/src/WebCamControl.Gtk/Widgets/CameraControlSlider.cs
@@ -13,7 +13,7 @@ public class CameraControlSlider : ActionRow
 	private readonly Scale _scale;
 
 	private CameraControlSlider(ICameraControl<int> control)
-		: base(Adw.Internal.ActionRow.New(), false)
+		: base(new Adw.Internal.ActionRowHandle(Adw.Internal.ActionRow.New(), false))
 	{
 		_control = control;
 		Title = control.Name;

--- a/src/WebCamControl.Gtk/Widgets/CameraControlSwitch.cs
+++ b/src/WebCamControl.Gtk/Widgets/CameraControlSwitch.cs
@@ -13,7 +13,7 @@ public class CameraControlSwitch : Box
 	private readonly SwitchRow _switch;
 
 	private CameraControlSwitch(ICameraControl<bool> control)
-		: base(global::Gtk.Internal.Box.New(Orientation.Horizontal, 0), false)
+		: base(new global::Gtk.Internal.BoxHandle(global::Gtk.Internal.Box.New(Orientation.Horizontal, 0), false))
 	{
 		_control = control;
 		// SwitchRow is `final`, so we can't inherit from it. Instead, append the switch

--- a/src/WebCamControl.Gtk/Widgets/PanAndTiltButtons.blp
+++ b/src/WebCamControl.Gtk/Widgets/PanAndTiltButtons.blp
@@ -4,7 +4,8 @@ Grid pan_and_tilt_buttons {
   column-spacing: 4;
   row-spacing: 4;
 
-  Button _up {
+  // TODO: Use qualifiedName once available.
+  $WebCamControlGtkWidgetsPressAndHoldButton _up {
     tooltip-text: _('Up');
     icon-name: 'go-up';
     width-request: 50;
@@ -16,7 +17,7 @@ Grid pan_and_tilt_buttons {
     }
   }
 
-  Button _down {
+  $WebCamControlGtkWidgetsPressAndHoldButton _down {
     tooltip-text: _('Down');
     icon-name: 'go-down';
     width-request: 50;
@@ -28,7 +29,7 @@ Grid pan_and_tilt_buttons {
     }
   }
 
-  Button _left {
+  $WebCamControlGtkWidgetsPressAndHoldButton _left {
     tooltip-text: _('Left');
     icon-name: 'go-previous';
     width-request: 50;
@@ -40,7 +41,7 @@ Grid pan_and_tilt_buttons {
     }
   }
 
-  Button _right {
+  $WebCamControlGtkWidgetsPressAndHoldButton _right {
     tooltip-text: _('Right');
     icon-name: 'go-next';
     width-request: 50;

--- a/src/WebCamControl.Gtk/Widgets/PanAndTiltButtons.cs
+++ b/src/WebCamControl.Gtk/Widgets/PanAndTiltButtons.cs
@@ -23,10 +23,13 @@ public class PanAndTiltButtons : Box
 	[Connect] private readonly PressAndHoldButton _left = default!;
 	[Connect] private readonly PressAndHoldButton _right = default!;
 #pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
-	
+
 	public PanAndTiltButtons(ICamera camera)
 	{
 		_camera = camera;
+		// Ensure PressAndHoldButton's GObject type is registered before the Builder
+		// tries to instantiate it from the UI definition.
+		PressAndHoldButton.GetGType();
 		_builder = new Builder("PanAndTiltButtons.ui");
 		var rootWidget = (Grid)_builder.GetObject("pan_and_tilt_buttons")!;
 		Append(rootWidget);
@@ -44,7 +47,7 @@ public class PanAndTiltButtons : Box
 			_left.OnHeld += (_, _) => _camera.Pan.Value -= _panTiltAdjustmentAmount;
 			_right.OnHeld += (_, _) => _camera.Pan.Value += _panTiltAdjustmentAmount;
 		}
-	
+
 		_down.DisableCameraControlIfUnsupported(_camera.Tilt);
 		_up.DisableCameraControlIfUnsupported(_camera.Tilt);
 		if (_camera.Tilt != null)

--- a/src/WebCamControl.Gtk/Widgets/PresetRow.cs
+++ b/src/WebCamControl.Gtk/Widgets/PresetRow.cs
@@ -16,10 +16,10 @@ public class PresetRow : ExpanderRow
 	public PresetRow(PresetConfig preset)
 		: this(Adw.Internal.ExpanderRow.New(), false, preset)
 	{
-		
+
 	}
 	private PresetRow(IntPtr ptr, bool ownedRef, PresetConfig preset)
-		: base(ptr, ownedRef)
+		: base(new Adw.Internal.ExpanderRowHandle(ptr, ownedRef))
 	{
 		_preset = preset;
 		Title = preset.Name;

--- a/src/WebCamControl.Gtk/Widgets/PressAndHoldButton.cs
+++ b/src/WebCamControl.Gtk/Widgets/PressAndHoldButton.cs
@@ -1,32 +1,29 @@
+using GObject;
 using Gtk;
 using Timer = System.Timers.Timer;
 
 namespace WebCamControl.Gtk.Widgets;
 
 /// <summary>
-/// A button that emits events while it is being held in.
+/// A <see cref="Button"/> that emits events while it is being held in.
+/// TODO: Use qualifiedName once available.
 /// </summary>
-public class PressAndHoldButton : Button
+[Subclass<Button>]
+public partial class PressAndHoldButton
 {
 	private readonly Timer _timer = new(TimeSpan.FromMilliseconds(100));
-	
-	protected internal PressAndHoldButton(IntPtr ptr, bool ownedRef)
-		: base(ptr, ownedRef)
-	{
-		AttachEvents();
-	}
 
-	public event EventHandler OnHeld;
+	public event EventHandler? OnHeld;
 
-	private void AttachEvents()
+	partial void Initialize()
 	{
-		_timer.Elapsed += (_, _) => OnHeld(this, EventArgs.Empty);
-		
+		_timer.Elapsed += (_, _) => OnHeld?.Invoke(this, EventArgs.Empty);
+
 		var gesture = GestureClick.New();
 		gesture.PropagationPhase = PropagationPhase.Capture;
 		gesture.OnPressed += (_, _) =>
 		{
-			OnHeld(this, EventArgs.Empty);
+			OnHeld?.Invoke(this, EventArgs.Empty);
 			_timer.Start();
 		};
 		gesture.OnReleased += (_, _) => _timer.Stop();


### PR DESCRIPTION
Upgrade from Gir.Core 0.5.0 to 0.7.0. Partially assisted by Claude Code.

Changes:
 - `PressAndHoldButton` is now a properly registered custom GObject, to handle the subclassing changes in Gir.Core 0.6.0.
 - Changed `CustomComboRow` to wrap the ComboRow rather than subclass it. It can't be a GObject subclass as it uses generics.
 - Updated components to pass correct type to `base` constructor.