### PR TITLE
Show warning when controls are out of range.

### DIFF
--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WebCamControl\n"
-"POT-Creation-Date: 2025-07-27 16:01:43-0700\n"
-"PO-Revision-Date: 2025-07-27 16:01:43-0700\n"
+"POT-Creation-Date: 2026-04-26 14:38:38-0700\n"
+"PO-Revision-Date: 2026-04-26 14:38:39-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -10,30 +10,60 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: GetText.NET Extractor\n"
 
-#: WebCamControl.Core/Linux/LinuxCameraManager.cs:72
+#: WebCamControl.Core/Linux/LinuxCameraManager.cs:88
 msgid "No cameras were found"
 msgstr ""
 
-#: WebCamControl.Gtk/MiniWindow.cs:85
+#: WebCamControl.Gtk/MiniWindow.cs:99
 msgid ""
 "No saved preset. Use the 'Save Preset' menu option or press Ctrl+S to save "
 "one."
+msgstr ""
+
+#: WebCamControl.Gtk/OutOfRangeDialog.cs:50
+msgid "Reset"
 msgstr ""
 
 #: WebCamControl.Gtk/Application.cs:178
 msgid "Exiting..."
 msgstr ""
 
+#: WebCamControl.Gtk/OutOfRangeDialog.cs:49
+msgid "Ignore"
+msgstr ""
+
+#: WebCamControl.Core/Linux/LinuxCameraControl.cs:107
+msgid ""
+"This could be caused by a bug in your camera's driver or firmware. Make sure "
+"the firmware is up-to-date."
+msgstr ""
+
+#: WebCamControl.Gtk/OutOfRangeDialog.cs:93
+msgid "OK"
+msgstr ""
+
 #: WebCamControl.Gtk/AboutWindow.cs:26
 msgid "translator-credits"
 msgstr ""
 
-#: WebCamControl.Gtk/MiniWindow.cs:119
+#: WebCamControl.Gtk/OutOfRangeDialog.cs:26
+msgid ""
+"Your camera has control values that are out of range. This is a bug with the "
+"camera's firmware or driver. To try and recover, WebCamControl can attempt "
+"to reset these controls to their default values."
+msgstr ""
+
+#: WebCamControl.Gtk/MiniWindow.cs:133
 #, csharp-format
 msgid "Zoom: {0}%"
 msgstr ""
 
-#: WebCamControl.Gtk/ErrorDialog.cs:25
+#: WebCamControl.Core/Linux/LinuxCameraControl.cs:100
+#, csharp-format
+msgid "Could not set {0}: {1} ({2})."
+msgstr ""
+
+#: WebCamControl.Gtk/ErrorDialog.cs:22
 #, csharp-format
 msgid ""
 "Error: {0}\n"
@@ -50,9 +80,13 @@ msgstr ""
 msgid "New preset"
 msgstr ""
 
-#: WebCamControl.Gtk/MiniWindow.cs:80
+#: WebCamControl.Gtk/MiniWindow.cs:94
 #, csharp-format
 msgid "Apply preset \"{0}\""
+msgstr ""
+
+#: WebCamControl.Gtk/OutOfRangeDialog.cs:90
+msgid "Some controls could not be reset:"
 msgstr ""
 
 #: WebCamControl.Gtk/MiniWindow.blp:13
@@ -85,10 +119,6 @@ msgstr ""
 
 #: WebCamControl.Gtk/ErrorDialog.blp:18
 msgid "Details"
-msgstr ""
-
-#: WebCamControl.Gtk/ErrorDialog.blp:34
-msgid "OK"
 msgstr ""
 
 #: WebCamControl.Gtk/ErrorDialog.blp:35

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: WebCamControl\n"
-"POT-Creation-Date: 2026-04-26 14:38:38-0700\n"
-"PO-Revision-Date: 2026-04-26 14:38:39-0700\n"
+"POT-Creation-Date: 2026-05-02 16:45:41-0700\n"
+"PO-Revision-Date: 2026-05-02 16:45:41-0700\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -10,11 +10,21 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: GetText.NET Extractor\n"
 
+#: WebCamControl.Gtk/OutOfRangeDialog.cs:90
+msgid ""
+"Some controls could not be reset. This is a bug with your webcam, NOT with "
+"WebCamControl."
+msgstr ""
+
 #: WebCamControl.Core/Linux/LinuxCameraManager.cs:88
 msgid "No cameras were found"
 msgstr ""
 
-#: WebCamControl.Gtk/MiniWindow.cs:99
+#: WebCamControl.Gtk/OutOfRangeDialog.cs:94
+msgid "An error has occurred"
+msgstr ""
+
+#: WebCamControl.Gtk/MiniWindow.cs:95
 msgid ""
 "No saved preset. Use the 'Save Preset' menu option or press Ctrl+S to save "
 "one."
@@ -24,7 +34,7 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: WebCamControl.Gtk/Application.cs:178
+#: WebCamControl.Gtk/Application.cs:170
 msgid "Exiting..."
 msgstr ""
 
@@ -38,11 +48,11 @@ msgid ""
 "the firmware is up-to-date."
 msgstr ""
 
-#: WebCamControl.Gtk/OutOfRangeDialog.cs:93
+#: WebCamControl.Gtk/OutOfRangeDialog.cs:98
 msgid "OK"
 msgstr ""
 
-#: WebCamControl.Gtk/AboutWindow.cs:26
+#: WebCamControl.Gtk/AboutWindow.cs:24
 msgid "translator-credits"
 msgstr ""
 
@@ -53,9 +63,13 @@ msgid ""
 "to reset these controls to their default values."
 msgstr ""
 
-#: WebCamControl.Gtk/MiniWindow.cs:133
+#: WebCamControl.Gtk/MiniWindow.cs:132
 #, csharp-format
 msgid "Zoom: {0}%"
+msgstr ""
+
+#: WebCamControl.Gtk/OutOfRangeDialog.cs:45
+msgid "Out of range values"
 msgstr ""
 
 #: WebCamControl.Core/Linux/LinuxCameraControl.cs:100
@@ -63,7 +77,7 @@ msgstr ""
 msgid "Could not set {0}: {1} ({2})."
 msgstr ""
 
-#: WebCamControl.Gtk/ErrorDialog.cs:22
+#: WebCamControl.Gtk/ErrorDialog.cs:19
 #, csharp-format
 msgid ""
 "Error: {0}\n"
@@ -71,22 +85,23 @@ msgid ""
 "If this is unexpected, please report a bug."
 msgstr ""
 
-#: WebCamControl.Gtk/SavePresetDialog.cs:55
+#: WebCamControl.Gtk/SavePresetDialog.cs:63
 #, csharp-format
 msgid "Replace #{0}: {1}"
 msgstr ""
 
-#: WebCamControl.Gtk/SavePresetDialog.cs:58
+#: WebCamControl.Gtk/SavePresetDialog.cs:68
 msgid "New preset"
 msgstr ""
 
-#: WebCamControl.Gtk/MiniWindow.cs:94
+#: WebCamControl.Gtk/MiniWindow.cs:90
 #, csharp-format
 msgid "Apply preset \"{0}\""
 msgstr ""
 
-#: WebCamControl.Gtk/OutOfRangeDialog.cs:90
-msgid "Some controls could not be reset:"
+#: WebCamControl.Gtk/OutOfRangeDialog.cs:35
+#, csharp-format
+msgid "• {0}: Set to {1} but should be between {2} and {3}."
 msgstr ""
 
 #: WebCamControl.Gtk/MiniWindow.blp:13
@@ -113,10 +128,6 @@ msgstr ""
 msgid "Quit"
 msgstr ""
 
-#: WebCamControl.Gtk/ErrorDialog.blp:5
-msgid "An error has occurred"
-msgstr ""
-
 #: WebCamControl.Gtk/ErrorDialog.blp:18
 msgid "Details"
 msgstr ""
@@ -134,19 +145,19 @@ msgstr ""
 msgid "Camera"
 msgstr ""
 
-#: WebCamControl.Gtk/FullWindow.blp:48
+#: WebCamControl.Gtk/FullWindow.blp:44
 msgid "Image"
 msgstr ""
 
-#: WebCamControl.Gtk/FullWindow.blp:57
+#: WebCamControl.Gtk/FullWindow.blp:53
 msgid "Pan and Tilt"
 msgstr ""
 
-#: WebCamControl.Gtk/FullWindow.blp:68
+#: WebCamControl.Gtk/FullWindow.blp:64
 msgid "Brightness"
 msgstr ""
 
-#: WebCamControl.Gtk/FullWindow.blp:88
+#: WebCamControl.Gtk/FullWindow.blp:84
 msgid "Presets"
 msgstr ""
 

--- a/src/WebCamControl.Core/AngleControl.cs
+++ b/src/WebCamControl.Core/AngleControl.cs
@@ -12,6 +12,7 @@ public class AngleControl(ICameraControl<int> control) : ICameraControl<float>
 	public float Maximum => control.Maximum / _arcsecondsInDegree;
 	public float Step => control.Step / _arcsecondsInDegree;
 	public bool IsEnabled => control.IsEnabled;
+	public float Default => control.Default / _arcsecondsInDegree;
 
 	public float Value
 	{

--- a/src/WebCamControl.Core/BooleanControl.cs
+++ b/src/WebCamControl.Core/BooleanControl.cs
@@ -10,6 +10,7 @@ public class BooleanControl(ICameraControl<int> control) : ICameraControl<bool>
 	public bool Maximum => true;
 	public bool Step => true;
 	public bool IsEnabled => control.IsEnabled;
+	public bool Default => control.Default == 1;
 
 	public bool Value
 	{

--- a/src/WebCamControl.Core/ICameraControl.cs
+++ b/src/WebCamControl.Core/ICameraControl.cs
@@ -28,6 +28,11 @@ public interface ICameraControl<T>
 	T Step { get; }
 	
 	/// <summary>
+	/// Gets the default value for this control.
+	/// </summary>
+	T Default { get; }
+	
+	/// <summary>
 	/// Gets or sets the value for this control.
 	/// </summary>
 	T Value { get; set; }
@@ -46,6 +51,14 @@ public interface ICameraControl<T>
 	/// Fired when the value of this control is changed.
 	/// </summary>
 	public event EventHandler Changed;
+
+	/// <summary>
+	/// Reset this control to its default value.
+	/// </summary>
+	public void Reset()
+	{
+		Value = Default;
+	}
 }
 
 /// <summary>

--- a/src/WebCamControl.Core/Linux/LinuxCamera.cs
+++ b/src/WebCamControl.Core/Linux/LinuxCamera.cs
@@ -206,6 +206,11 @@ public class LinuxCamera : ICamera
 	/// Any controls that are not supported as one of the high-level fields above.
 	/// </summary>
 	public LinuxCameraAdvancedControls RawControls { get; private set; } = new();
+
+	/// <summary>
+	/// All raw integer controls, from RawControls plus the first-class controls.
+	/// </summary>
+	internal IReadOnlyDictionary<ControlID, LinuxCameraControl> RawIntegerControls { get; private set; }
 	
 	private void CreateControls()
 	{
@@ -261,6 +266,8 @@ public class LinuxCamera : ICamera
 			"Finished enumerating controls. Errno = {Errno}", 
 			Marshal.GetLastPInvokeError()
 		);
+
+		RawIntegerControls = integers.ToImmutableDictionary();
 
 		integers.Remove(ControlID.Brightness, out var brightness);
 		Brightness = PercentControl.CreateIfNotNull(brightness);

--- a/src/WebCamControl.Core/Linux/LinuxCameraControl.cs
+++ b/src/WebCamControl.Core/Linux/LinuxCameraControl.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using WebCamControl.Core.Exceptions;
 using WebCamControl.Linux.Interop;
+using static WebCamControl.Core.Gettext;
 using static WebCamControl.Linux.Interop.Ioctl;
 
 namespace WebCamControl.Core.Linux;
@@ -50,6 +51,7 @@ public class LinuxCameraControl : ICameraControl, IDisposable
 	public int Minimum => _controlData.Minimum;
 	public int Maximum => _controlData.Maximum;
 	public int Step => _controlData.Step;
+	public int Default => _controlData.DefaultValue;
 
 	public bool IsEnabled =>
 		!_controlData.Flags.HasFlag(ControlFlags.Disabled) &&
@@ -66,7 +68,15 @@ public class LinuxCameraControl : ICameraControl, IDisposable
 				ID = _id,
 			};
 			ioctl(_fd, IoctlCommand.GetControl, ref control);
-			InteropException.ThrowIfError();
+			try
+			{
+				InteropException.ThrowIfError();
+			}
+			catch (Exception ex)
+			{
+				_logger.LogWarning(ex, "GetControl({id}) = ERROR: {Error}", _id, ex.Message);
+			}
+
 			_logger.LogInformation("GetControl({id}) = {value}", _id, control.Value);
 			return control.Value;
 		}
@@ -85,12 +95,17 @@ public class LinuxCameraControl : ICameraControl, IDisposable
 			if (errno != 0)
 			{
 				var errMessage = Marshal.GetPInvokeErrorMessage(errno);
-				throw new Exception($"""
-					Could not set `{_id}`: {errMessage} ({errno}). 
-				    Min = {Minimum}, Max = {Maximum}, Step = {Step}
-				    Current = {Value}, New = {value}, ClampedNew = {clampedValue}.
-				    This could be caused by a bug in your camera's driver or firmware. Make sure the firmware is up-to-date."
-				""" );
+				// Only wrap translatable parts in `_`.
+				throw new Exception(
+					_($"Could not set {_id}: {errMessage} ({errno}).") + 
+					$"""
+					 
+					 Min = {Minimum}, Max = {Maximum}, Step = {Step}
+					 Current = {Value}, New = {value}, ClampedNew = {clampedValue}.
+
+					 """ +
+					_($"This could be caused by a bug in your camera's driver or firmware. Make sure the firmware is up-to-date.")
+				);
 			}
 			_logger.LogInformation("SetControl({id}, {value})", _id, clampedValue);
 			Changed?.Invoke(this, EventArgs.Empty);

--- a/src/WebCamControl.Core/OutOfRangeDetector.cs
+++ b/src/WebCamControl.Core/OutOfRangeDetector.cs
@@ -31,7 +31,7 @@ public class OutOfRangeDetector(
 			{
 				value = control.Value;
 			}
-			catch (Exception _)
+			catch (Exception)
 			{
 				// Ignore exceptions when reading values
 				continue;

--- a/src/WebCamControl.Core/OutOfRangeDetector.cs
+++ b/src/WebCamControl.Core/OutOfRangeDetector.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Daniel Lo Nigro <d@d.sb>
+
+using Microsoft.Extensions.Logging;
+using WebCamControl.Core.Linux;
+
+namespace WebCamControl.Core;
+
+/// <summary>
+/// Detects when any of a camera's controls are out of range.
+/// </summary>
+public class OutOfRangeDetector(
+	ICamera _camera,
+	ILogger<OutOfRangeDetector> _logger
+)
+{
+	/// <summary>
+	/// Detect out-of-range values for the specified camera.
+	/// </summary>
+	public IEnumerable<Result> Detect()
+	{
+		if (_camera is not LinuxCamera linuxCamera)
+		{
+			yield break;
+		}
+
+		foreach (var (id, control) in linuxCamera.RawIntegerControls)
+		{
+			int value;
+			try
+			{
+				value = control.Value;
+			}
+			catch (Exception _)
+			{
+				// Ignore exceptions when reading values
+				continue;
+			}
+
+			if (value >= control.Minimum && value <= control.Maximum)
+			{
+				continue;
+			}
+			
+			_logger.LogWarning(
+				"{ID} is out of range! Min = {Minimum}, Max = {Maximum}, Current = {Value}",
+				id,
+				control.Minimum,
+				control.Maximum,
+				value
+			);
+			yield return new Result(id.ToString(), control);
+		}
+	}
+
+	/// <summary>
+	/// A camera control that's out of range
+	/// </summary>
+	public record Result(
+		string Name,
+		ICameraControl Control
+	);
+}

--- a/src/WebCamControl.Core/PercentControl.cs
+++ b/src/WebCamControl.Core/PercentControl.cs
@@ -10,6 +10,7 @@ public class PercentControl(ICameraControl<int> control) : ICameraControl<int>
 	public int Maximum => 100;
 	public int Step => MapValueToPercentage(control.Step);
 	public bool IsEnabled => control.IsEnabled;
+	public int Default => MapValueToPercentage(control.Default);
 
 	public int Value
 	{

--- a/src/WebCamControl.Gtk/ErrorDialog.cs
+++ b/src/WebCamControl.Gtk/ErrorDialog.cs
@@ -30,7 +30,6 @@ public partial class ErrorDialog
 		dialog.Configure(ex);
 		dialog.OnResponse += (_, args) =>
 		{
-			Console.WriteLine(args.Response);
 			if (args.Response == "report_bug")
 			{
 				ReportBug(ex);

--- a/src/WebCamControl.Gtk/Extensions/AlertDialogExtensions.cs
+++ b/src/WebCamControl.Gtk/Extensions/AlertDialogExtensions.cs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Daniel Lo Nigro <d@d.sb>
+
+using Gtk;
+
+namespace WebCamControl.Gtk.Extensions;
+
+public static class AlertDialogExtensions
+{
+	extension(Adw.AlertDialog) {
+		/// <summary>
+		/// For dialogs with a lot of text, where the default center alignment looks ugly.
+		/// </summary>
+		public static Adw.AlertDialog NewWithLeftAlignedText(string heading, string body)
+		{
+			var bodyLabel = Label.New(body);
+			bodyLabel.Wrap = true;
+			bodyLabel.Halign = Align.Start;
+			bodyLabel.Justify = Justification.Left;
+
+			var dialog = Adw.AlertDialog.New(heading, null);
+			dialog.ExtraChild = bodyLabel;
+			return dialog;
+		} 
+	}
+}

--- a/src/WebCamControl.Gtk/MiniWindow.cs
+++ b/src/WebCamControl.Gtk/MiniWindow.cs
@@ -22,6 +22,7 @@ public partial class MiniWindow : IWidgetWithServiceLocator<MiniWindow>
 	
 	private ICamera _camera = null!;
 	private IPresets _presets = null!;
+	private IServiceProvider _provider = null!;
 	private EventHandler? _presetsChangedHandler;
 	private EventHandler? _zoomChangedHandler;
 
@@ -35,13 +36,19 @@ public partial class MiniWindow : IWidgetWithServiceLocator<MiniWindow>
 		var cameraManager = provider.GetRequiredService<ICameraManager>();
 		var presets = provider.GetRequiredService<IPresets>();
 		var window = NewWithProperties([]);
-		window.Configure(app, cameraManager, presets);
+		window.Configure(app, provider, cameraManager, presets);
 		return window;
 	}
 
-	private void Configure(Adw.Application app, ICameraManager cameraManager, IPresets presets)
+	private void Configure(
+		Adw.Application app,
+		IServiceProvider provider,
+		ICameraManager cameraManager,
+		IPresets presets
+	)
 	{
 		_camera = cameraManager.SelectedCamera;
+		_provider = provider;
 		_presets = presets;
 		Application = app;
 		Title = $"WebCamControl: {_camera.Name}";
@@ -53,6 +60,8 @@ public partial class MiniWindow : IWidgetWithServiceLocator<MiniWindow>
 
 		_presetsChangedHandler = (_, _) => InitializePresets();
 		presets.OnChange += _presetsChangedHandler;
+		
+		CheckOutOfRangeControls();
 	}
 
 	private void InitializePresets()
@@ -121,6 +130,16 @@ public partial class MiniWindow : IWidgetWithServiceLocator<MiniWindow>
 		_zoom.SetValue(_camera.Zoom.Value);
 		_zoom.Sensitive = _camera.Zoom.IsEnabled;
 		_zoom.TooltipText = _($"Zoom: {_camera.Zoom.Value}%");
+	}
+	
+	private void CheckOutOfRangeControls()
+	{
+		var detector = ActivatorUtilities.CreateInstance<OutOfRangeDetector>(_provider, _camera);
+		var outOfRange = detector.Detect().ToArray();
+		if (outOfRange.Length != 0)
+		{
+			OutOfRangeDialog.Show(outOfRange, this);
+		}
 	}
 
 	public override void Dispose()

--- a/src/WebCamControl.Gtk/OutOfRangeDialog.cs
+++ b/src/WebCamControl.Gtk/OutOfRangeDialog.cs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Daniel Lo Nigro <d@d.sb>
+
+using System.Text;
+using Adw;
+using Gtk;
+using WebCamControl.Core;
+using WebCamControl.Gtk.Extensions;
+using static WebCamControl.Core.Gettext;
+
+namespace WebCamControl.Gtk;
+
+public static class OutOfRangeDialog
+{
+	private const string ResetResponse = "reset";
+	private const string IgnoreResponse = "ignore";
+	private const string OKResponse = "okay";
+
+	public static void Show(
+		IList<OutOfRangeDetector.Result> outOfRangeControls,
+		Widget? parent
+	)
+	{
+		var body = new StringBuilder();
+		body.AppendLine(_(
+			"Your camera has control values that are out of range. This is a bug with the " +
+			"camera's firmware or driver. To try and recover, WebCamControl can attempt to reset " +
+			"these controls to their default values."
+		));
+		body.AppendLine();
+		
+		foreach (var (name, control) in outOfRangeControls)
+		{
+			body.AppendLine(_(
+				$"{name}: Set to {control.Value} but should be between {control.Minimum} and {control.Maximum}."
+			));
+		}
+		
+		var bodyLabel = Label.New(body.ToString());
+		bodyLabel.Wrap = true;
+		bodyLabel.Halign = Align.Start;
+		bodyLabel.Justify = Justification.Left;
+
+		var dialog = Adw.AlertDialog.NewWithLeftAlignedText(
+			_("Out of range values"), 
+			body.ToString()
+		);
+		dialog.WidthRequest = 600;
+		dialog.AddResponse(IgnoreResponse, _("Ignore"));
+		dialog.AddResponse(ResetResponse, _("Reset"));
+		dialog.CloseResponse = IgnoreResponse;
+		dialog.DefaultResponse = ResetResponse;
+		dialog.SetResponseAppearance(ResetResponse, ResponseAppearance.Suggested);
+		
+		dialog.OnResponse += (_, args) =>
+		{
+			if (args.Response == ResetResponse)
+			{
+				Reset(outOfRangeControls, dialog);
+			}
+			dialog.Close();
+		};
+		dialog.Present(parent);
+	}
+
+	private static void Reset(
+		IEnumerable<OutOfRangeDetector.Result> outOfRangeControls,
+		Widget parent
+	)
+	{
+		var errors = new List<string>();
+		foreach (var (name, control) in outOfRangeControls)
+		{
+			try
+			{
+				control.Reset();
+			}
+			catch (Exception ex)
+			{
+				errors.Add($"{name}\n{ex.Message}");
+			}
+		}
+
+		if (errors.Count == 0)
+		{
+			return;
+		}
+
+		var body = 
+			_("Some controls could not be reset:") + "\n\n" + string.Join("\n\n", errors);
+		var dialog = Adw.AlertDialog.NewWithLeftAlignedText(
+			_("An error has occurred"),
+			body
+		);
+		dialog.WidthRequest = 600;
+		dialog.AddResponse(OKResponse, _("OK"));
+		dialog.OnResponse += (_, args) => dialog.Close();
+		dialog.Present(parent);
+	}
+}

--- a/src/WebCamControl.Gtk/OutOfRangeDialog.cs
+++ b/src/WebCamControl.Gtk/OutOfRangeDialog.cs
@@ -32,7 +32,7 @@ public static class OutOfRangeDialog
 		foreach (var (name, control) in outOfRangeControls)
 		{
 			body.AppendLine(_(
-				$"{name}: Set to {control.Value} but should be between {control.Minimum} and {control.Maximum}."
+				$"• {name}: Set to {control.Value} but should be between {control.Minimum} and {control.Maximum}."
 			));
 		}
 		
@@ -86,8 +86,10 @@ public static class OutOfRangeDialog
 			return;
 		}
 
-		var body = 
-			_("Some controls could not be reset:") + "\n\n" + string.Join("\n\n", errors);
+		var body = _(
+			"Some controls could not be reset. This is a bug with your webcam, NOT with "+
+			"WebCamControl."
+		) + "\n\n" + string.Join("\n\n", errors);
 		var dialog = Adw.AlertDialog.NewWithLeftAlignedText(
 			_("An error has occurred"),
 			body


### PR DESCRIPTION
Several users have reported seeing a "Numerical result out of range" exception when using WebCamControl.

In these cases, the webcam's controls are **already** out of range. For example, from https://github.com/Daniel15/WebCamControl/issues/34#issuecomment-4286926505:

```
pan_absolute 0x009a0908 (int)    : min=-522000 max=522000 step=3600 default=0 value=36805668 flags=0x00001000
```

WebCamControl tries to do the right thing and clamps the new value (attempts to set it to the maximum possible, `522000`), but the camera driver throws a "Numerical result out of range" range, even though it's clearly within the range.

I think the only reasonable approach we can take is for WebCamControl to check all the values at startup, and offer to reset any out-of-range values back to the default value. That's what's implemented in this PR.

---

On startup, if any values are out of range, this dialog pops up:

<img width="919" height="430" alt="image" src="https://github.com/user-attachments/assets/e125e8da-33f0-4121-a347-65ce0ef93a1b" />

(this value is not actually out of range, but I just hard-coded it to test)

If "reset" is clicked, the value is reset to the default (`0` in the case of tilt). If "ignore" is clicked, the controls are left as-is, but might encounter issues later.

---

References #34